### PR TITLE
Add a dependabot config for maven projects

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add dependabot configuration for Maven projects.

* Create a new file named `dependabot.yml` in the `.github` directory.
* Add configuration for Maven projects.
* Specify the directory to scan for dependencies as `/`.
* Set the package-ecosystem to "maven".
* Set the update schedule to "weekly".

